### PR TITLE
remove stale dep on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='WSGIProxy2',
       packages=find_packages(exclude=['ez_setup', 'README_fixt', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=['webob', 'six'],
+      install_requires=['webob'],
       entry_points="""
       # -*- Entry points: -*-
       """,

--- a/wsgiproxy/proxies.py
+++ b/wsgiproxy/proxies.py
@@ -3,7 +3,6 @@ from webob import exc
 from webob.compat import PY3, url_quote
 import logging
 import socket
-import six
 import re
 
 try:
@@ -227,7 +226,7 @@ class Proxy(object):
         start_response(status, headers)
 
         if method == "HEAD":
-            return [six.b('')]
+            return [b'']
 
         return app_iter
 


### PR DESCRIPTION
six was only needed for Python 2 support.  Now that the package supports
only Python 3, the dependency on six can be removed.